### PR TITLE
table width not set until user resizes a column

### DIFF
--- a/src/app/public/modules/grid/grid.component.spec.ts
+++ b/src/app/public/modules/grid/grid.component.spec.ts
@@ -821,6 +821,18 @@ describe('Grid Component', () => {
           let column2 = component.columnWidthsChange.find(cwc => cwc.id === 'column2');
           expect(column2).not.toBeNull();
         }));
+
+        it('should NOT set table width if selectedColumnIds property changes and user has NOT resized columns', fakeAsync(() => {
+          // Update selected columns.
+          component.selectedColumnIds = ['column1'];
+          fixture.detectChanges();
+          tick();
+
+          const table = getTable(fixture);
+          const tableStyle = table.nativeElement.getAttribute('style');
+
+          expect(tableStyle).toBeNull();
+        }));
       });
     });
 

--- a/src/app/public/modules/grid/grid.component.ts
+++ b/src/app/public/modules/grid/grid.component.ts
@@ -125,7 +125,10 @@ export class SkyGridComponent implements OnInit, AfterContentInit, OnChanges, On
             selectedColumnIds: newIds
           });
           this.selectedColumnIdsChange.emit(this._selectedColumnIds);
-          this.resetTableWidth();
+
+          if (this.isResized) {
+            this.resetTableWidth();
+          }
         }
 
     }


### PR DESCRIPTION
Prior to this PR, we were always setting table width when the selectedColumnIds changed. This change makes sure the user has opted-in to column resizing before running that logic.

This prevents issues consumers were seeing when upgrading from older versions of grids. The new version would show all columns having equal width (instead of auto-adjusting based on the content inside them).
