### PR TITLE
Prevent touch devices from scrolling grid while dragging column

### DIFF
--- a/src/app/public/modules/grid/grid.component.html
+++ b/src/app/public/modules/grid/grid.component.html
@@ -32,6 +32,7 @@
             [style.width.px]="column.width"
             (mouseup)="sortByColumn(column)"
             (keydown)="onKeydown($event, column)"
+            (touchmove)="onTouchMove($event)"
             #gridCol
           >
             <div

--- a/src/app/public/modules/grid/grid.component.spec.ts
+++ b/src/app/public/modules/grid/grid.component.spec.ts
@@ -1663,6 +1663,16 @@ describe('Grid Component', () => {
       expect(setOptionsSpy).toHaveBeenCalled();
     });
 
+    it('should prevent default behavior when dragging columns on mobile devices', () => {
+      fixture.detectChanges();
+      fixture.detectChanges();
+      const eventSpy = jasmine.createSpyObj('event', ['preventDefault']);
+
+      SkyGridComponent.prototype.onTouchMove(eventSpy);
+
+      expect(eventSpy.preventDefault).toHaveBeenCalled();
+    });
+
     it('should pass accessibility', async(() => {
       fixture.detectChanges();
       fixture.detectChanges();

--- a/src/app/public/modules/grid/grid.component.ts
+++ b/src/app/public/modules/grid/grid.component.ts
@@ -545,6 +545,11 @@ export class SkyGridComponent implements OnInit, AfterContentInit, OnChanges, On
     return false;
   }
 
+  // Prevent touch devices from inadvertently scrolling grid while dragging columns.
+  public onDrag(event: any): void {
+    event.preventDefault();
+  }
+
   private multiselectSelectAll() {
     for (let i = 0; i < this.items.length; i++) {
       this.items[i].isSelected = true;

--- a/src/app/public/modules/grid/grid.component.ts
+++ b/src/app/public/modules/grid/grid.component.ts
@@ -546,7 +546,7 @@ export class SkyGridComponent implements OnInit, AfterContentInit, OnChanges, On
   }
 
   // Prevent touch devices from inadvertently scrolling grid while dragging columns.
-  public onDrag(event: any): void {
+  public onTouchMove(event: any): void {
     event.preventDefault();
   }
 


### PR DESCRIPTION
Tested on iOS Simulator. Verified horizontal/vertical scrolling no longer happens while dragging a column.