### PR TITLE
Add missing null check for the table header class names

### DIFF
--- a/src/app/public/modules/grid/grid.component.ts
+++ b/src/app/public/modules/grid/grid.component.ts
@@ -347,7 +347,7 @@ export class SkyGridComponent implements OnInit, AfterContentInit, OnChanges, On
   public getTableHeaderClassNames(column: SkyGridColumnModel) {
     let classNames: string[] = [];
 
-    if (column.locked) {
+    if (column && column.locked) {
       classNames.push('sky-grid-header-locked');
     }
 


### PR DESCRIPTION
This one is unfortunately hard to test due to it not being clearly reproducable but this null check will ensure that the SPA does not crash if this occurs again